### PR TITLE
Support BoringSSL in xorNonceAEAD

### DIFF
--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -3,9 +3,11 @@ package handshake
 import (
 	"crypto"
 	"crypto/aes"
+	"crypto/boring"
 	"crypto/cipher"
 	"crypto/tls"
 	"fmt"
+	"os"
 
 	"golang.org/x/crypto/chacha20poly1305"
 )
@@ -13,6 +15,8 @@ import (
 // These cipher suite implementations are copied from the standard library crypto/tls package.
 
 const aeadNonceLength = 12
+
+var useBoring = len(os.Getenv("USE_BORING")) != 0
 
 type cipherSuite struct {
 	ID     uint16
@@ -44,12 +48,17 @@ func aeadAESGCMTLS13(key, nonceMask []byte) *xorNonceAEAD {
 	if err != nil {
 		panic(err)
 	}
-	aead, err := cipher.NewGCM(aes)
+	var aead cipher.AEAD
+	if useBoring && boring.Enabled() {
+		aead, err = tls.NewGCMTLS13(aes)
+	} else {
+		aead, err = cipher.NewGCM(aes)
+	}
 	if err != nil {
 		panic(err)
 	}
 
-	ret := &xorNonceAEAD{aead: aead}
+	ret := &xorNonceAEAD{aead: aead, hasSeenNonceZero: false}
 	copy(ret.nonceMask[:], nonceMask)
 	return ret
 }
@@ -71,15 +80,41 @@ func aeadChaCha20Poly1305(key, nonceMask []byte) *xorNonceAEAD {
 // xorNonceAEAD wraps an AEAD by XORing in a fixed pattern to the nonce
 // before each call.
 type xorNonceAEAD struct {
-	nonceMask [aeadNonceLength]byte
-	aead      cipher.AEAD
+	nonceMask        [aeadNonceLength]byte
+	aead             cipher.AEAD
+	hasSeenNonceZero bool
 }
 
 func (f *xorNonceAEAD) NonceSize() int        { return 8 } // 64-bit sequence number
 func (f *xorNonceAEAD) Overhead() int         { return f.aead.Overhead() }
 func (f *xorNonceAEAD) explicitNonceLen() int { return 0 }
 
+func allZeros(nonce []byte) bool {
+	for _, e := range nonce {
+		if e != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 func (f *xorNonceAEAD) Seal(out, nonce, plaintext, additionalData []byte) []byte {
+	if useBoring && !f.hasSeenNonceZero {
+		f.hasSeenNonceZero = true
+		if !allZeros(nonce) {
+			f.sealZeroNonce(nonce)
+		}
+	}
+
+	return f.seal(nonce, out, plaintext, additionalData)
+}
+
+func (f *xorNonceAEAD) sealZeroNonce(nonce []byte) {
+	zeroNonce := make([]byte, len(nonce))
+	f.seal([]byte{}, zeroNonce, []byte{}, []byte{})
+}
+
+func (f *xorNonceAEAD) seal(nonce []byte, out []byte, plaintext []byte, additionalData []byte) []byte {
 	for i, b := range nonce {
 		f.nonceMask[4+i] ^= b
 	}

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -15,11 +15,14 @@ import (
 
 // These cipher suite implementations are copied from the standard library crypto/tls package.
 
-const aeadNonceLength = 12
+const (
+	aeadNonceLength = 12
+)
 
 var (
 	useBoring             = len(os.Getenv("USE_BORING")) != 0
-	errBoringIsNotEnabled = errors.New("Boring was requested but not enabled")
+	errBoringIsNotEnabled = errors.New("boring was requested but not enabled")
+	zeroNonce             = [aeadNonceLength]byte{}
 )
 
 type cipherSuite struct {
@@ -129,8 +132,8 @@ func (f *xorNonceAEAD) Seal(out, nonce, plaintext, additionalData []byte) []byte
 }
 
 func (f *xorNonceAEAD) sealZeroNonce() {
-	zeroNonce := make([]byte, aeadNonceLength)
-	f.seal([]byte{}, zeroNonce, []byte{}, []byte{})
+	zeroNonce := [aeadNonceLength]byte{}
+	f.seal([]byte{}, zeroNonce[:], []byte{}, []byte{})
 }
 
 func (f *xorNonceAEAD) seal(nonce []byte, out []byte, plaintext []byte, additionalData []byte) []byte {

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -107,15 +107,21 @@ func allZeros(nonce []byte) bool {
 }
 
 func (f *xorNonceAEAD) Seal(out, nonce, plaintext, additionalData []byte) []byte {
-	if useBoring && boring.Enabled() && !f.hasSeenNonceZero {
-		// BoringSSL expects that the first nonce passed to the
-		// AEAD instance is zero.
-		// At this point the nonce argument is either zero or
-		// an artificial one will be passed to the AEAD through
-		// [sealZeroNonce]
-		f.hasSeenNonceZero = true
-		if !allZeros(nonce) {
-			f.sealZeroNonce()
+	if useBoring {
+		if boring.Enabled() {
+			if !f.hasSeenNonceZero {
+				// BoringSSL expects that the first nonce passed to the
+				// AEAD instance is zero.
+				// At this point the nonce argument is either zero or
+				// an artificial one will be passed to the AEAD through
+				// [sealZeroNonce]
+				f.hasSeenNonceZero = true
+				if !allZeros(nonce) {
+					f.sealZeroNonce()
+				}
+			}
+		} else {
+			panic(errBoringIsNotEnabled)
 		}
 	}
 

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -6,6 +6,7 @@ import (
 	"crypto/boring"
 	"crypto/cipher"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"os"
 
@@ -16,7 +17,10 @@ import (
 
 const aeadNonceLength = 12
 
-var useBoring = len(os.Getenv("USE_BORING")) != 0
+var (
+	useBoring             = len(os.Getenv("USE_BORING")) != 0
+	errBoringIsNotEnabled = errors.New("Boring was requested but not enabled")
+)
 
 type cipherSuite struct {
 	ID     uint16
@@ -49,8 +53,12 @@ func aeadAESGCMTLS13(key, nonceMask []byte) *xorNonceAEAD {
 		panic(err)
 	}
 	var aead cipher.AEAD
-	if useBoring && boring.Enabled() {
-		aead, err = tls.NewGCMTLS13(aes)
+	if useBoring {
+		if boring.Enabled() {
+			aead, err = tls.NewGCMTLS13(aes)
+		} else {
+			err = errBoringIsNotEnabled
+		}
 	} else {
 		aead, err = cipher.NewGCM(aes)
 	}
@@ -82,7 +90,7 @@ func aeadChaCha20Poly1305(key, nonceMask []byte) *xorNonceAEAD {
 type xorNonceAEAD struct {
 	nonceMask        [aeadNonceLength]byte
 	aead             cipher.AEAD
-	hasSeenNonceZero bool
+	hasSeenNonceZero bool // This value denotes if the aead field was used with a nonce = 0
 }
 
 func (f *xorNonceAEAD) NonceSize() int        { return 8 } // 64-bit sequence number
@@ -99,18 +107,23 @@ func allZeros(nonce []byte) bool {
 }
 
 func (f *xorNonceAEAD) Seal(out, nonce, plaintext, additionalData []byte) []byte {
-	if useBoring && !f.hasSeenNonceZero {
+	if useBoring && boring.Enabled() && !f.hasSeenNonceZero {
+		// BoringSSL expects that the first nonce passed to the
+		// AEAD instance is zero.
+		// At this point the nonce argument is either zero or
+		// an artificial one will be passed to the AEAD through
+		// [sealZeroNonce]
 		f.hasSeenNonceZero = true
 		if !allZeros(nonce) {
-			f.sealZeroNonce(nonce)
+			f.sealZeroNonce()
 		}
 	}
 
 	return f.seal(nonce, out, plaintext, additionalData)
 }
 
-func (f *xorNonceAEAD) sealZeroNonce(nonce []byte) {
-	zeroNonce := make([]byte, len(nonce))
+func (f *xorNonceAEAD) sealZeroNonce() {
+	zeroNonce := make([]byte, aeadNonceLength)
 	f.seal([]byte{}, zeroNonce, []byte{}, []byte{})
 }
 


### PR DESCRIPTION
Add support for BoringSSL which is controlled by an environment variable. 
The changes also includes the logic that when the first nonce of xorNonceAEAD isn't the nonce = 0 then it provides one.