### PR TITLE
TUN-8853: use conditional compilation to support Go without BoringSSL

### DIFF
--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -3,12 +3,9 @@ package handshake
 import (
 	"crypto"
 	"crypto/aes"
-	"crypto/boring"
 	"crypto/cipher"
 	"crypto/tls"
-	"errors"
 	"fmt"
-	"os"
 
 	"golang.org/x/crypto/chacha20poly1305"
 )
@@ -17,12 +14,6 @@ import (
 
 const (
 	aeadNonceLength = 12
-)
-
-var (
-	useBoring             = len(os.Getenv("USE_BORING")) != 0
-	errBoringIsNotEnabled = errors.New("boring was requested but not enabled")
-	zeroNonce             = [aeadNonceLength]byte{}
 )
 
 type cipherSuite struct {
@@ -55,16 +46,8 @@ func aeadAESGCMTLS13(key, nonceMask []byte) *xorNonceAEAD {
 	if err != nil {
 		panic(err)
 	}
-	var aead cipher.AEAD
-	if useBoring {
-		if boring.Enabled() {
-			aead, err = tls.NewGCMTLS13(aes)
-		} else {
-			err = errBoringIsNotEnabled
-		}
-	} else {
-		aead, err = cipher.NewGCM(aes)
-	}
+
+	aead, err := newAEAD(aes)
 	if err != nil {
 		panic(err)
 	}
@@ -100,43 +83,11 @@ func (f *xorNonceAEAD) NonceSize() int        { return 8 } // 64-bit sequence nu
 func (f *xorNonceAEAD) Overhead() int         { return f.aead.Overhead() }
 func (f *xorNonceAEAD) explicitNonceLen() int { return 0 }
 
-func allZeros(nonce []byte) bool {
-	for _, e := range nonce {
-		if e != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 func (f *xorNonceAEAD) Seal(out, nonce, plaintext, additionalData []byte) []byte {
-	if useBoring {
-		if boring.Enabled() {
-			if !f.hasSeenNonceZero {
-				// BoringSSL expects that the first nonce passed to the
-				// AEAD instance is zero.
-				// At this point the nonce argument is either zero or
-				// an artificial one will be passed to the AEAD through
-				// [sealZeroNonce]
-				f.hasSeenNonceZero = true
-				if !allZeros(nonce) {
-					f.sealZeroNonce()
-				}
-			}
-		} else {
-			panic(errBoringIsNotEnabled)
-		}
-	}
-
 	return f.seal(nonce, out, plaintext, additionalData)
 }
 
-func (f *xorNonceAEAD) sealZeroNonce() {
-	zeroNonce := [aeadNonceLength]byte{}
-	f.seal([]byte{}, zeroNonce[:], []byte{}, []byte{})
-}
-
-func (f *xorNonceAEAD) seal(nonce []byte, out []byte, plaintext []byte, additionalData []byte) []byte {
+func (f *xorNonceAEAD) doSeal(nonce, out, plaintext, additionalData []byte) []byte {
 	for i, b := range nonce {
 		f.nonceMask[4+i] ^= b
 	}

--- a/internal/handshake/xor_nonce_aead_boring.go
+++ b/internal/handshake/xor_nonce_aead_boring.go
@@ -1,0 +1,64 @@
+//go:build boringcrypto
+
+package handshake
+
+import (
+	"crypto/boring"
+	"crypto/cipher"
+	"crypto/tls"
+	"errors"
+	"os"
+)
+
+var (
+	useBoring             = len(os.Getenv("USE_BORING")) != 0
+	errBoringIsNotEnabled = errors.New("boring was requested but not enabled")
+	zeroNonce             = [aeadNonceLength]byte{}
+)
+
+func newAEAD(aes cipher.Block) (cipher.AEAD, error) {
+	if useBoring {
+		if boring.Enabled() {
+			return tls.NewGCMTLS13(aes)
+		} else {
+			return nil, errBoringIsNotEnabled
+		}
+	} else {
+		return cipher.NewGCM(aes)
+	}
+}
+
+func allZeros(nonce []byte) bool {
+	for _, e := range nonce {
+		if e != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *xorNonceAEAD) sealZeroNonce() {
+	f.doSeal([]byte{}, zeroNonce[:], []byte{}, []byte{})
+}
+
+func (f *xorNonceAEAD) seal(out, nonce, plaintext, additionalData []byte) []byte {
+	if useBoring {
+		if boring.Enabled() {
+			if !f.hasSeenNonceZero {
+				// BoringSSL expects that the first nonce passed to the
+				// AEAD instance is zero.
+				// At this point the nonce argument is either zero or
+				// an artificial one will be passed to the AEAD through
+				// [sealZeroNonce]
+				f.hasSeenNonceZero = true
+				if !allZeros(nonce) {
+					f.sealZeroNonce()
+				}
+			}
+		} else {
+			panic(errBoringIsNotEnabled)
+		}
+	}
+
+	return f.doSeal(out, nonce, plaintext, additionalData)
+}

--- a/internal/handshake/xor_nonce_aead_noboring.go
+++ b/internal/handshake/xor_nonce_aead_noboring.go
@@ -1,0 +1,13 @@
+//go:build !boringcrypto
+
+package handshake
+
+import "crypto/cipher"
+
+func newAEAD(aes cipher.Block) (cipher.AEAD, error) {
+	return cipher.NewGCM(aes)
+}
+
+func (f *xorNonceAEAD) seal(nonce, out, plaintext, additionalData []byte) []byte {
+	return f.doSeal(nonce, out, plaintext, additionalData)
+}


### PR DESCRIPTION
I've reverted the cipher_suite.go changes and instead added conditional compilation.
The issue is that the import of crypto/boring requires the binary to be compiled with the boringcrypto tag which would force the cloudflare compilation to always use BoringSSL.