### PR TITLE
TUN-8853: fix argument order and nonce buffer in xor_nonce_aead_borin…

### DIFF
--- a/internal/handshake/xor_nonce_aead_boring.go
+++ b/internal/handshake/xor_nonce_aead_boring.go
@@ -13,7 +13,6 @@ import (
 var (
 	useBoring             = len(os.Getenv("USE_BORING")) != 0
 	errBoringIsNotEnabled = errors.New("boring was requested but not enabled")
-	zeroNonce             = [aeadNonceLength]byte{}
 )
 
 func newAEAD(aes cipher.Block) (cipher.AEAD, error) {
@@ -38,10 +37,10 @@ func allZeros(nonce []byte) bool {
 }
 
 func (f *xorNonceAEAD) sealZeroNonce() {
-	f.doSeal([]byte{}, zeroNonce[:], []byte{}, []byte{})
+	f.doSeal([]byte{}, []byte{}, []byte{}, []byte{})
 }
 
-func (f *xorNonceAEAD) seal(out, nonce, plaintext, additionalData []byte) []byte {
+func (f *xorNonceAEAD) seal(nonce, out, plaintext, additionalData []byte) []byte {
 	if useBoring {
 		if boring.Enabled() {
 			if !f.hasSeenNonceZero {
@@ -60,5 +59,5 @@ func (f *xorNonceAEAD) seal(out, nonce, plaintext, additionalData []byte) []byte
 		}
 	}
 
-	return f.doSeal(out, nonce, plaintext, additionalData)
+	return f.doSeal(nonce, out, plaintext, additionalData)
 }


### PR DESCRIPTION
The PR https://github.com/chungthuang/quic-go/pull/5 introduced the xor_nonce_aead_boring.go and xor_nonce_aead_noboring.go however there was a mistake in the order of the arguments passed to the seal function of xor_nonce_aead_boring.go.