### PR TITLE
Apply patches for QUIC-GO

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"reflect"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -296,6 +298,16 @@ var newConnection = func(
 	)
 	s.currentMTUEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(s.config.InitialPacketSize))))
 	statelessResetToken := statelessResetter.GetStatelessResetToken(srcConnID)
+	// Allow server to define custom MaxUDPPayloadSize
+	maxUDPPayloadSize := protocol.MaxPacketBufferSize
+	if maxPacketSize := os.Getenv("TUNNEL_MAX_QUIC_PACKET_SIZE"); maxPacketSize != "" {
+		if customMaxPacketSize, err := strconv.ParseUint(maxPacketSize, 10, 64); err == nil {
+			maxUDPPayloadSize = int(customMaxPacketSize)
+		} else {
+			utils.DefaultLogger.Errorf("failed to parse TUNNEL_MAX_QUIC_PACKET_SIZE: %v", err)
+		}
+	}
+
 	params := &wire.TransportParameters{
 		InitialMaxStreamDataBidiLocal:   protocol.ByteCount(s.config.InitialStreamReceiveWindow),
 		InitialMaxStreamDataBidiRemote:  protocol.ByteCount(s.config.InitialStreamReceiveWindow),
@@ -306,7 +318,7 @@ var newConnection = func(
 		MaxUniStreamNum:                 protocol.StreamNum(s.config.MaxIncomingUniStreams),
 		MaxAckDelay:                     protocol.MaxAckDelayInclGranularity,
 		AckDelayExponent:                protocol.AckDelayExponent,
-		MaxUDPPayloadSize:               protocol.MaxPacketBufferSize,
+		MaxUDPPayloadSize:               protocol.ByteCount(maxUDPPayloadSize),
 		StatelessResetToken:             &statelessResetToken,
 		OriginalDestinationConnectionID: origDestConnID,
 		// For interoperability with quic-go versions before May 2023, this value must be set to a value

--- a/internal/handshake/xor_nonce_aead_boring.go
+++ b/internal/handshake/xor_nonce_aead_boring.go
@@ -1,0 +1,51 @@
+//go:build boringcrypto
+
+package handshake
+
+import (
+	"crypto/cipher"
+	"crypto/tls"
+	"os"
+	"strings"
+)
+
+var goBoringDisabled bool = strings.TrimSpace(os.Getenv("QUIC_GO_DISABLE_BORING")) == "1"
+
+func newAEAD(aes cipher.Block) (cipher.AEAD, error) {
+	if goBoringDisabled {
+		// In case Go Boring is disabled then
+		// fallback to normal cryptographic procedure.
+		return cipher.NewGCM(aes)
+	}
+	return tls.NewGCMTLS13(aes)
+}
+
+func allZeros(nonce []byte) bool {
+	for _, e := range nonce {
+		if e != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (f *xorNonceAEAD) sealZeroNonce() {
+	f.doSeal([]byte{}, []byte{}, []byte{}, []byte{})
+}
+
+func (f *xorNonceAEAD) seal(nonce, out, plaintext, additionalData []byte) []byte {
+	if !goBoringDisabled {
+		if !f.hasSeenNonceZero {
+			// BoringSSL expects that the first nonce passed to the
+			// AEAD instance is zero.
+			// At this point the nonce argument is either zero or
+			// an artificial one will be passed to the AEAD through
+			// [sealZeroNonce]
+			f.hasSeenNonceZero = true
+			if !allZeros(nonce) {
+				f.sealZeroNonce()
+			}
+		}
+	}
+	return f.doSeal(nonce, out, plaintext, additionalData)
+}

--- a/internal/handshake/xor_nonce_aead_noboring.go
+++ b/internal/handshake/xor_nonce_aead_noboring.go
@@ -1,0 +1,13 @@
+//go:build !boringcrypto
+
+package handshake
+
+import "crypto/cipher"
+
+func newAEAD(aes cipher.Block) (cipher.AEAD, error) {
+	return cipher.NewGCM(aes)
+}
+
+func (f *xorNonceAEAD) seal(nonce, out, plaintext, additionalData []byte) []byte {
+	return f.doSeal(nonce, out, plaintext, additionalData)
+}


### PR DESCRIPTION
Patches applied
- Allow server to specify custom max UDP payload size
- Support BoringSSL in QUIC-GO when encrypting packets



Note: the 2nd patch was squashed for the full history check https://github.com/lmpn/quic-go/tree/cloudflare-backup