### PR TITLE
Add CreatedIncomingStreams hook to ConnectionTracer

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -507,6 +507,7 @@ func (s *connection) preSetup() {
 		uint64(s.config.MaxIncomingStreams),
 		uint64(s.config.MaxIncomingUniStreams),
 		s.perspective,
+		s.tracer,
 	)
 	s.framer = newFramer(s.connFlowController)
 	s.receivedPackets.Init(8)

--- a/logging/connection_tracer.go
+++ b/logging/connection_tracer.go
@@ -38,6 +38,12 @@ type ConnectionTracer struct {
 	LossTimerCanceled                func()
 	ECNStateUpdated                  func(state ECNState, trigger ECNStateTrigger)
 	ChoseALPN                        func(protocol string)
+	// CreatedIncomingStreams is called when one or more incoming stream objects are
+	// created to satisfy a peer-initiated stream frame. gap is the number of stream
+	// objects created (in StreamNum space, i.e. increments of 1 per stream, not 4).
+	// A gap greater than 1 means intermediate streams were allocated to satisfy
+	// RFC 9000 §3.2 ordering requirements.
+	CreatedIncomingStreams func(streamType StreamType, gap StreamNum)
 	// Close is called when the connection is closed.
 	Close func()
 	Debug func(name, msg string)

--- a/logging/connection_tracer.go
+++ b/logging/connection_tracer.go
@@ -40,10 +40,9 @@ type ConnectionTracer struct {
 	ChoseALPN                        func(protocol string)
 	// CreatedIncomingStreams is called when one or more incoming stream objects are
 	// created to satisfy a peer-initiated stream frame. gap is the number of stream
-	// objects created (in StreamNum space, i.e. increments of 1 per stream, not 4).
-	// A gap greater than 1 means intermediate streams were allocated to satisfy
-	// RFC 9000 §3.2 ordering requirements.
-	CreatedIncomingStreams func(streamType StreamType, gap StreamNum)
+	// objects created. A gap greater than 1 means intermediate streams were allocated
+	// to satisfy RFC 9000 §3.2 ordering requirements.
+	CreatedIncomingStreams func(streamType StreamType, gap uint64)
 	// Close is called when the connection is closed.
 	Close func()
 	Debug func(name, msg string)

--- a/logging/connection_tracer_multiplexer.go
+++ b/logging/connection_tracer_multiplexer.go
@@ -218,6 +218,13 @@ func NewMultiplexedConnectionTracer(tracers ...*ConnectionTracer) *ConnectionTra
 				}
 			}
 		},
+		CreatedIncomingStreams: func(streamType StreamType, gap StreamNum) {
+			for _, t := range tracers {
+				if t.CreatedIncomingStreams != nil {
+					t.CreatedIncomingStreams(streamType, gap)
+				}
+			}
+		},
 		Close: func() {
 			for _, t := range tracers {
 				if t.Close != nil {

--- a/logging/connection_tracer_multiplexer.go
+++ b/logging/connection_tracer_multiplexer.go
@@ -218,7 +218,7 @@ func NewMultiplexedConnectionTracer(tracers ...*ConnectionTracer) *ConnectionTra
 				}
 			}
 		},
-		CreatedIncomingStreams: func(streamType StreamType, gap StreamNum) {
+		CreatedIncomingStreams: func(streamType StreamType, gap uint64) {
 			for _, t := range tracers {
 				if t.CreatedIncomingStreams != nil {
 					t.CreatedIncomingStreams(streamType, gap)

--- a/streams_map.go
+++ b/streams_map.go
@@ -9,6 +9,7 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/logging"
 )
 
 type streamError struct {
@@ -50,6 +51,8 @@ type streamsMap struct {
 	queueControlFrame func(wire.Frame)
 	newFlowController func(protocol.StreamID) flowcontrol.StreamFlowController
 
+	tracer *logging.ConnectionTracer
+
 	mutex               sync.Mutex
 	outgoingBidiStreams *outgoingStreamsMap[streamI]
 	outgoingUniStreams  *outgoingStreamsMap[sendStreamI]
@@ -68,6 +71,7 @@ func newStreamsMap(
 	maxIncomingBidiStreams uint64,
 	maxIncomingUniStreams uint64,
 	perspective protocol.Perspective,
+	tracer *logging.ConnectionTracer,
 ) *streamsMap {
 	m := &streamsMap{
 		ctx:                    ctx,
@@ -77,6 +81,7 @@ func newStreamsMap(
 		maxIncomingBidiStreams: maxIncomingBidiStreams,
 		maxIncomingUniStreams:  maxIncomingUniStreams,
 		sender:                 sender,
+		tracer:                 tracer,
 	}
 	m.initMaps()
 	return m
@@ -99,6 +104,7 @@ func (m *streamsMap) initMaps() {
 		},
 		m.maxIncomingBidiStreams,
 		m.queueControlFrame,
+		m.tracer,
 	)
 	m.outgoingUniStreams = newOutgoingStreamsMap(
 		protocol.StreamTypeUni,
@@ -116,6 +122,7 @@ func (m *streamsMap) initMaps() {
 		},
 		m.maxIncomingUniStreams,
 		m.queueControlFrame,
+		m.tracer,
 	)
 }
 

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -114,7 +114,7 @@ func (m *incomingStreamsMap[T]) GetOrOpenStream(num protocol.StreamNum) (T, erro
 		// consumers can observe anomalous stream ID jumps regardless of whether
 		// MaxIncomingStreams is set to a finite value.
 		if num > nextToOpen && m.tracer != nil && m.tracer.CreatedIncomingStreams != nil {
-			m.tracer.CreatedIncomingStreams(m.streamType, num-nextToOpen+1)
+			m.tracer.CreatedIncomingStreams(m.streamType, uint64(num-nextToOpen+1))
 		}
 		return *new(T), streamError{
 			message: "peer tried to open stream %d (current limit: %d)",
@@ -140,7 +140,7 @@ func (m *incomingStreamsMap[T]) GetOrOpenStream(num protocol.StreamNum) (T, erro
 	// * maxStream can only increase, so if the id was valid before, it definitely is valid now
 	// * highestStream is only modified by this function
 	if m.tracer != nil && m.tracer.CreatedIncomingStreams != nil {
-		m.tracer.CreatedIncomingStreams(m.streamType, num-m.nextStreamToOpen+1)
+		m.tracer.CreatedIncomingStreams(m.streamType, uint64(num-m.nextStreamToOpen+1))
 	}
 	for newNum := m.nextStreamToOpen; newNum <= num; newNum++ {
 		m.streams[newNum] = incomingStreamEntry[T]{stream: m.newStream(newNum)}

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/logging"
 )
 
 type incomingStream interface {
@@ -34,6 +35,8 @@ type incomingStreamsMap[T incomingStream] struct {
 	newStream        func(protocol.StreamNum) T
 	queueMaxStreamID func(*wire.MaxStreamsFrame)
 
+	tracer *logging.ConnectionTracer
+
 	closeErr error
 }
 
@@ -42,6 +45,7 @@ func newIncomingStreamsMap[T incomingStream](
 	newStream func(protocol.StreamNum) T,
 	maxStreams uint64,
 	queueControlFrame func(wire.Frame),
+	tracer *logging.ConnectionTracer,
 ) *incomingStreamsMap[T] {
 	return &incomingStreamsMap[T]{
 		newStreamChan:      make(chan struct{}, 1),
@@ -53,6 +57,7 @@ func newIncomingStreamsMap[T incomingStream](
 		nextStreamToOpen:   1,
 		nextStreamToAccept: 1,
 		queueMaxStreamID:   func(f *wire.MaxStreamsFrame) { queueControlFrame(f) },
+		tracer:             tracer,
 	}
 }
 
@@ -125,6 +130,9 @@ func (m *incomingStreamsMap[T]) GetOrOpenStream(num protocol.StreamNum) (T, erro
 	// no need to check the two error conditions from above again
 	// * maxStream can only increase, so if the id was valid before, it definitely is valid now
 	// * highestStream is only modified by this function
+	if m.tracer != nil && m.tracer.CreatedIncomingStreams != nil {
+		m.tracer.CreatedIncomingStreams(m.streamType, num-m.nextStreamToOpen+1)
+	}
 	for newNum := m.nextStreamToOpen; newNum <= num; newNum++ {
 		m.streams[newNum] = incomingStreamEntry[T]{stream: m.newStream(newNum)}
 		select {

--- a/streams_map_incoming.go
+++ b/streams_map_incoming.go
@@ -105,8 +105,17 @@ func (m *incomingStreamsMap[T]) AcceptStream(ctx context.Context) (T, error) {
 
 func (m *incomingStreamsMap[T]) GetOrOpenStream(num protocol.StreamNum) (T, error) {
 	m.mutex.RLock()
+	// Capture nextStreamToOpen while holding the read lock so we can compute
+	// the gap for the hook in both the reject and accept paths below.
+	nextToOpen := m.nextStreamToOpen
 	if num > m.maxStream {
 		m.mutex.RUnlock()
+		// Fire the hook even when the stream is rejected by the limit, so that
+		// consumers can observe anomalous stream ID jumps regardless of whether
+		// MaxIncomingStreams is set to a finite value.
+		if num > nextToOpen && m.tracer != nil && m.tracer.CreatedIncomingStreams != nil {
+			m.tracer.CreatedIncomingStreams(m.streamType, num-nextToOpen+1)
+		}
 		return *new(T), streamError{
 			message: "peer tried to open stream %d (current limit: %d)",
 			nums:    []protocol.StreamNum{num, m.maxStream},

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -335,4 +335,12 @@ func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
 	_, err = m.GetOrOpenStream(3)
 	require.NoError(t, err)
 	require.Len(t, calls, 2)
+
+	// A stream ID beyond the limit is rejected, but the hook still fires so
+	// that consumers can observe the anomalous jump even when MaxIncomingStreams
+	// is set to a finite value. At this point nextStreamToOpen=7, so gap=2000-7+1=1994.
+	_, err = m.GetOrOpenStream(2000)
+	require.Error(t, err)
+	require.Len(t, calls, 3)
+	require.Equal(t, protocol.StreamNum(1994), calls[2].gap)
 }

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -329,6 +329,7 @@ func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
 	_, err = m.GetOrOpenStream(6)
 	require.NoError(t, err)
 	require.Len(t, calls, 2)
+	require.Equal(t, protocol.StreamTypeBidi, calls[1].streamType)
 	require.Equal(t, protocol.StreamNum(1), calls[1].gap)
 
 	// Opening an already-known stream does not fire the hook.
@@ -342,5 +343,6 @@ func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
 	_, err = m.GetOrOpenStream(2000)
 	require.Error(t, err)
 	require.Len(t, calls, 3)
+	require.Equal(t, protocol.StreamTypeBidi, calls[2].streamType)
 	require.Equal(t, protocol.StreamNum(1994), calls[2].gap)
 }

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/logging"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,7 @@ func TestStreamsMapIncomingGettingStreams(t *testing.T) {
 		},
 		maxNumStreams,
 		func(f wire.Frame) {},
+		nil,
 	)
 
 	// all streams up to the id on GetOrOpenStream are opened
@@ -79,6 +81,7 @@ func TestStreamsMapIncomingAcceptingStreams(t *testing.T) {
 		func(num protocol.StreamNum) *mockGenericStream { return &mockGenericStream{num: num} },
 		5,
 		func(f wire.Frame) {},
+		nil,
 	)
 
 	errChan := make(chan error, 1)
@@ -128,6 +131,7 @@ func TestStreamsMapIncomingDeletingStreams(t *testing.T) {
 		func(num protocol.StreamNum) *mockGenericStream { return &mockGenericStream{num: num} },
 		5,
 		func(f wire.Frame) { frameQueue = append(frameQueue, f) },
+		nil,
 	)
 	err := m.DeleteStream(1337)
 	require.Error(t, err)
@@ -173,6 +177,7 @@ func TestStreamsMapIncomingDeletingStreamsWithHighLimits(t *testing.T) {
 		func(num protocol.StreamNum) *mockGenericStream { return &mockGenericStream{num: num} },
 		uint64(protocol.MaxStreamCount-2),
 		func(f wire.Frame) { frameQueue = append(frameQueue, f) },
+		nil,
 	)
 
 	// open a bunch of streams
@@ -202,6 +207,7 @@ func TestStreamsMapIncomingClosing(t *testing.T) {
 		func(num protocol.StreamNum) *mockGenericStream { return &mockGenericStream{num: num} },
 		5,
 		func(f wire.Frame) {},
+		nil,
 	)
 
 	var streams []*mockGenericStream
@@ -243,6 +249,7 @@ func TestStreamsMapIncomingRandomized(t *testing.T) {
 		func(num protocol.StreamNum) *mockGenericStream { return &mockGenericStream{num: num} },
 		num,
 		func(f wire.Frame) {},
+		nil,
 	)
 
 	ids := make([]protocol.StreamNum, num)
@@ -289,4 +296,43 @@ func TestStreamsMapIncomingRandomized(t *testing.T) {
 	case <-time.After(timeout * 3 / 2):
 		t.Fatal("timeout")
 	}
+}
+
+func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
+	type hookCall struct {
+		streamType logging.StreamType
+		gap        protocol.StreamNum
+	}
+	var calls []hookCall
+	tracer := &logging.ConnectionTracer{
+		CreatedIncomingStreams: func(streamType logging.StreamType, gap protocol.StreamNum) {
+			calls = append(calls, hookCall{streamType: streamType, gap: gap})
+		},
+	}
+
+	m := newIncomingStreamsMap(
+		protocol.StreamTypeBidi,
+		func(num protocol.StreamNum) *mockGenericStream { return &mockGenericStream{num: num} },
+		1000,
+		func(f wire.Frame) {},
+		tracer,
+	)
+
+	// Opening stream 5 from a watermark of 1 should create a gap of 5.
+	_, err := m.GetOrOpenStream(5)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	require.Equal(t, protocol.StreamTypeBidi, calls[0].streamType)
+	require.Equal(t, protocol.StreamNum(5), calls[0].gap)
+
+	// Opening the very next stream (6) is gap=1 — the normal case.
+	_, err = m.GetOrOpenStream(6)
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	require.Equal(t, protocol.StreamNum(1), calls[1].gap)
+
+	// Opening an already-known stream does not fire the hook.
+	_, err = m.GetOrOpenStream(3)
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
 }

--- a/streams_map_incoming_test.go
+++ b/streams_map_incoming_test.go
@@ -301,11 +301,11 @@ func TestStreamsMapIncomingRandomized(t *testing.T) {
 func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
 	type hookCall struct {
 		streamType logging.StreamType
-		gap        protocol.StreamNum
+		gap        uint64
 	}
 	var calls []hookCall
 	tracer := &logging.ConnectionTracer{
-		CreatedIncomingStreams: func(streamType logging.StreamType, gap protocol.StreamNum) {
+		CreatedIncomingStreams: func(streamType logging.StreamType, gap uint64) {
 			calls = append(calls, hookCall{streamType: streamType, gap: gap})
 		},
 	}
@@ -323,14 +323,14 @@ func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, calls, 1)
 	require.Equal(t, protocol.StreamTypeBidi, calls[0].streamType)
-	require.Equal(t, protocol.StreamNum(5), calls[0].gap)
+	require.Equal(t, uint64(5), calls[0].gap)
 
 	// Opening the very next stream (6) is gap=1 — the normal case.
 	_, err = m.GetOrOpenStream(6)
 	require.NoError(t, err)
 	require.Len(t, calls, 2)
 	require.Equal(t, protocol.StreamTypeBidi, calls[1].streamType)
-	require.Equal(t, protocol.StreamNum(1), calls[1].gap)
+	require.Equal(t, uint64(1), calls[1].gap)
 
 	// Opening an already-known stream does not fire the hook.
 	_, err = m.GetOrOpenStream(3)
@@ -344,5 +344,5 @@ func TestStreamsMapIncomingCreatedIncomingStreamsHook(t *testing.T) {
 	require.Error(t, err)
 	require.Len(t, calls, 3)
 	require.Equal(t, protocol.StreamTypeBidi, calls[2].streamType)
-	require.Equal(t, protocol.StreamNum(1994), calls[2].gap)
+	require.Equal(t, uint64(1994), calls[2].gap)
 }

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -77,6 +77,7 @@ func testStreamsMapCreatingAndDeletingStreams(t *testing.T,
 		1,
 		1,
 		perspective,
+		nil,
 	)
 	m.UpdateLimits(&wire.TransportParameters{
 		MaxBidiStreamNum: protocol.MaxStreamCount,
@@ -168,6 +169,7 @@ func testStreamsMapDeletingStreams(t *testing.T,
 		100,
 		100,
 		perspective,
+		nil,
 	)
 	m.UpdateLimits(&wire.TransportParameters{
 		MaxBidiStreamNum: 10,
@@ -271,6 +273,7 @@ func testStreamsMapStreamLimits(t *testing.T, perspective protocol.Perspective) 
 		100,
 		100,
 		perspective,
+		nil,
 	)
 
 	// increase via transport parameters
@@ -328,6 +331,7 @@ func TestStreamsMapClosing(t *testing.T) {
 		1,
 		1,
 		protocol.PerspectiveClient,
+		nil,
 	)
 	m.CloseWithError(assert.AnError)
 	_, err := m.OpenStream()
@@ -358,6 +362,7 @@ func TestStreamsMap0RTT(t *testing.T) {
 		1,
 		1,
 		protocol.PerspectiveClient,
+		nil,
 	)
 	// restored transport parameters
 	m.UpdateLimits(&wire.TransportParameters{
@@ -393,6 +398,7 @@ func TestStreamsMap0RTTRejection(t *testing.T) {
 		1,
 		1,
 		protocol.PerspectiveClient,
+		nil,
 	)
 
 	m.ResetFor0RTT()


### PR DESCRIPTION
Exposes a new hook that fires whenever incoming stream objects are batch-created to satisfy RFC 9000 §3.2 ordering requirements. The hook receives the stream type and the gap (number of objects created, in StreamNum space). A gap of 1 is the normal case; a large gap indicates an anomalous peer-initiated stream ID that triggered mass allocation.

Consumers can use this to increment a counter metric and alert when the rate spikes above normal baseline, providing an early signal of the unbounded MaxIncomingStreams vulnerability before OOM occurs.